### PR TITLE
chore: add github dockerhub image cicd pipeline

### DIFF
--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -1,0 +1,34 @@
+name: Push Docker image to Docker Hub
+
+on:
+  push:
+    branches: [ main ]
+
+jobs:
+  push_to_registry:
+    name: Push Docker image to Docker Hub
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Check out the repo
+      uses: actions/checkout@v2
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v1
+
+    - name: Log in to Docker Hub
+      uses: docker/login-action@v1 
+      with:
+        username: ${{ secrets.DOCKER_HUB_USERNAME }}
+        password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+
+    - name: Extract branch name
+      shell: bash
+      run: echo "SHORT_SHA=$(echo ${{ github.sha }} | cut -c 1-7)" >> $GITHUB_ENV
+
+    - name: Build and push Docker image
+      uses: docker/build-push-action@v2
+      with:
+        context: .
+        push: true
+        tags: brobridgehub/gravity-dispatcher:${{ env.SHORT_SHA }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM golang:1.20.2-alpine3.17 AS builder
+WORKDIR /
+COPY . .
+
+RUN apk add --update build-base && apk upgrade --available
+RUN go build -o /gravity-dispatcher
+
+FROM alpine:3.17.2
+WORKDIR /
+RUN apk update && apk upgrade --available
+COPY ./configs /configs
+COPY --from=builder /gravity-dispatcher /gravity-dispatcher
+
+USER 1001
+
+ENTRYPOINT ["/gravity-dispatcher"]


### PR DESCRIPTION
add workflow to build docker hub when push to main branch, use commit hash (1-7) to represent image tag
<img width="934" alt="screenshot" src="https://github.com/BrobridgeOrg/gravity-dispatcher/assets/95557928/0c8407ad-e111-4b34-9ca4-a665f5e6e036">
