### PR TITLE
upgrade golang version to 1.24.0 in gravity-dispatcher/build/docker/Dockerfile ( #14 Issue )

### DIFF
--- a/build/docker/Dockerfile
+++ b/build/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.23.1-alpine3.20 AS builder
+FROM golang:1.24.0-alpine3.20 AS builder
 
 ENV GOBIN=/
 


### PR DESCRIPTION
#14 
# Change
Update the Go version in the Dockerfile from golang:1.23.1-alpine3.20 to golang:1.24.0-alpine3.20 to meet go.mod requires go version.